### PR TITLE
Fix/dct identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datacatalogtordf"
-version = "1.2.4"
+version = "1.3.0"
 description= "A library for mapping a data catalog to rdf"
 authors = ["Stig B. Dørmænen <stigbd@gmail.com>"]
 license = "Apache-2.0"

--- a/src/datacatalogtordf/catalog.py
+++ b/src/datacatalogtordf/catalog.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
-from rdflib import Graph, Namespace, RDF, URIRef
+from rdflib import Graph, Literal, Namespace, RDF, URIRef
 
 from .catalogrecord import CatalogRecord
 from .dataservice import DataService
@@ -68,6 +68,7 @@ class Catalog(Dataset):
         "_catalogs",
         "_catalogrecords",
         "_models",
+        "_dct_identifier",
     )
 
     _homepage: URI
@@ -78,6 +79,7 @@ class Catalog(Dataset):
     _catalogs: List[Catalog]
     _catalogrecords: List[CatalogRecord]
     _models: List[Any]
+    _dct_identifier: str
 
     def __init__(self) -> None:
         """Inits catalog object with default values."""
@@ -163,6 +165,16 @@ class Catalog(Dataset):
     def catalogrecords(self: Catalog, catalogrecords: List[CatalogRecord]) -> None:
         self._catalogrecords = catalogrecords
 
+    @property
+    def dct_identifier(self) -> str:
+        """Get for dct_identifier."""
+        return self._dct_identifier
+
+    @dct_identifier.setter
+    def dct_identifier(self, dct_identifier: str) -> None:
+        """Set for dct_identifier."""
+        self._dct_identifier = dct_identifier
+
         # -
 
     def to_rdf(
@@ -206,6 +218,7 @@ class Catalog(Dataset):
 
         self._g.add((URIRef(self.identifier), RDF.type, self._type))
 
+        self._dct_identifier_to_graph()
         self._homepage_to_graph()
         self._themes_to_graph()
         self._has_parts_to_graph()
@@ -231,6 +244,16 @@ class Catalog(Dataset):
                 self._g += model._to_graph()
 
         return self._g
+
+    def _dct_identifier_to_graph(self: Dataset) -> None:
+        if getattr(self, "dct_identifier", None):
+            self._g.add(
+                (
+                    URIRef(self.identifier),
+                    DCT.identifier,
+                    Literal(self.dct_identifier),
+                )
+            )
 
     def _homepage_to_graph(self: Catalog) -> None:
         if getattr(self, "homepage", None):

--- a/src/datacatalogtordf/dataset.py
+++ b/src/datacatalogtordf/dataset.py
@@ -71,6 +71,7 @@ class Dataset(Resource):
         "_temporal_resolution",
         "_was_generated_by",
         "_access_rights_comments",
+        "_dct_identifier",
     )
 
     # Types
@@ -82,6 +83,7 @@ class Dataset(Resource):
     _temporal_resolution: str
     _was_generated_by: URI
     _access_rights_comments: List[str]
+    _dct_identifier: str
 
     def __init__(self) -> None:
         """Inits an object with default values."""
@@ -164,6 +166,16 @@ class Dataset(Resource):
     ) -> None:
         self._access_rights_comments = access_rights_comments
 
+    @property
+    def dct_identifier(self) -> str:
+        """Get for dct_identifier."""
+        return self._dct_identifier
+
+    @dct_identifier.setter
+    def dct_identifier(self, dct_identifier: str) -> None:
+        """Set for dct_identifier."""
+        self._dct_identifier = dct_identifier
+
     # -
     def _to_graph(self: Dataset) -> Graph:
 
@@ -172,6 +184,7 @@ class Dataset(Resource):
 
         self._g.add((URIRef(self.identifier), RDF.type, self._type))
 
+        self._dct_identifier_to_graph()
         self._distributions_to_graph()
         self._frequency_to_graph()
         self._spatial_coverage_to_graph()
@@ -182,6 +195,16 @@ class Dataset(Resource):
         self._access_rights_comments_to_graph()
 
         return self._g
+
+    def _dct_identifier_to_graph(self: Dataset) -> None:
+        if getattr(self, "dct_identifier", None):
+            self._g.add(
+                (
+                    URIRef(self.identifier),
+                    DCT.identifier,
+                    Literal(self.dct_identifier),
+                )
+            )
 
     def _distributions_to_graph(self: Dataset) -> None:
         if getattr(self, "distributions", None):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -418,6 +418,32 @@ def test_to_graph_should_return_model_as_graph() -> None:
     assert _isomorphic
 
 
+def test_to_graph_should_return_dct_identifier_as_graph() -> None:
+    """It returns a dct_identifier graph isomorphic to spec."""
+    catalog = Catalog()
+    catalog.identifier = "http://example.com/catalogs/1"
+    catalog.dct_identifier = "Catalog_123456789"
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+    <http://example.com/catalogs/1>    a dcat:Catalog ;
+        dct:identifier "Catalog_123456789";
+    .
+    """
+    g1 = Graph().parse(data=catalog.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
 # ---------------------------------------------------------------------- #
 # Utils for displaying debug information
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -314,6 +314,32 @@ def test_to_graph_should_return_link_to_spatial_coverage_with_location_triple() 
     assert _isomorphic
 
 
+def test_to_graph_should_return_dct_identifier_as_graph() -> None:
+    """It returns a dct_identifier graph isomorphic to spec."""
+    dataset = Dataset()
+    dataset.identifier = "http://example.com/datasets/1"
+    dataset.dct_identifier = "Dataset_123456789"
+
+    src = """
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+    <http://example.com/datasets/1>    a dcat:Dataset ;
+        dct:identifier "Dataset_123456789";
+    .
+    """
+    g1 = Graph().parse(data=dataset.to_rdf(), format="turtle")
+    g2 = Graph().parse(data=src, format="turtle")
+
+    _isomorphic = isomorphic(g1, g2)
+    if not _isomorphic:
+        _dump_diff(g1, g2)
+        pass
+    assert _isomorphic
+
+
 # ---------------------------------------------------------------------- #
 # Utils for displaying debug information
 


### PR DESCRIPTION

Etter samtale med @stigbd  ble vi enige om følgende:

- Vi kobler ikkje dagens identifier til dct:identifier
- dct_identifier innføres som nytt felt, verdien blir eksponert i dct:identifier, og det overlates til bruker av biblioteket og evt gjenbruke (deler av) verdi frå identifier.

Vi innfører derfor ny property for alle klassene som iflg dcat-ap-no v2 har denne egenskapen.

https://github.com/Informasjonsforvaltning/datacatalogtordf/issues/25#issuecomment-817637316